### PR TITLE
add pfNetdevices to support multi interface on one server

### DIFF
--- a/sriov/sriov.go
+++ b/sriov/sriov.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"math/rand"
 
 	"github.com/Mellanox/sriovnet"
 	"github.com/containernetworking/cni/pkg/ipam"
@@ -32,20 +32,30 @@ type dpdkConf struct {
 	KDriver    string `json:"kernel_driver"`
 	DPDKDriver string `json:"dpdk_driver"`
 	DPDKtool   string `json:"dpdk_tool"`
-	VFID       int    `json: "vfid"`
+	VFID       int    `json:"vfid"`
 }
 
 type NetConf struct {
 	types.NetConf
-	DPDKMode bool
-	Sharedvf bool
-	DPDKConf dpdkConf `json:"dpdk,omitempty"`
-	CNIDir   string   `json:"cniDir"`
-	IF0      string   `json:"if0"`
-	IF0NAME  string   `json:"if0name"`
-	L2Mode   bool     `json:"l2enable"`
-	Vlan     int      `json:"vlan"`
+	DPDKMode     bool
+	Sharedvf     bool
+	DPDKConf     dpdkConf `json:"dpdk,omitempty"`
+	CNIDir       string   `json:"cniDir"`
+	IF0          string   `json:"if0"`
+	IF0NAME      string   `json:"if0name"`
+	L2Mode       bool     `json:"l2enable"`
+	Vlan         int      `json:"vlan"`
+	PfNetdevices []string `json:"pfNetdevices"`
 }
+
+type pfStat struct{
+	PFName string
+	VFNum int
+}
+type pfStats []*pfStat
+func (s pfStats) Len() int      { return len(s) }
+func (s pfStats) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s pfStats) Less(i, j int) bool {return s[i].VFNum > s[j].VFNum }
 
 // Link names given as os.FileInfo need to be sorted by their Index
 
@@ -94,8 +104,8 @@ func loadConf(bytes []byte) (*NetConf, error) {
 		}
 	}
 
-	if n.IF0 == "" {
-		return nil, fmt.Errorf(`"if0" field is required. It specifies the host interface name to virtualize`)
+	if n.IF0 == "" && len(n.PfNetdevices) == 0 {
+		return nil, fmt.Errorf(`"if0" or "pfNetdevices" field is required. It specifies the host interface name to virtualize`)
 	}
 
 	if n.CNIDir == "" {
@@ -136,8 +146,8 @@ func consumeScratchNetConf(containerID, dataDir string) ([]byte, error) {
 	return data, err
 }
 
-func savedpdkConf(cid, dataDir string, conf *NetConf) error {
-	dpdkconfBytes, err := json.Marshal(conf.DPDKConf)
+func saveNetConf(cid, dataDir string, conf *NetConf) error {
+	confBytes, err := json.Marshal(conf)
 	if err != nil {
 		return fmt.Errorf("error serializing delegate netconf: %v", err)
 	}
@@ -146,27 +156,48 @@ func savedpdkConf(cid, dataDir string, conf *NetConf) error {
 	cRef := strings.Join(s, "-")
 
 	// save the rendered netconf for cmdDel
-	if err = saveScratchNetConf(cRef, dataDir, dpdkconfBytes); err != nil {
+	if err = saveScratchNetConf(cRef, dataDir, confBytes); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (dc *dpdkConf) getdpdkConf(cid, podIfName, dataDir string, conf *NetConf) error {
+func (nc *NetConf) getNetConf(cid, podIfName, dataDir string, conf *NetConf) error {
 	s := []string{cid, podIfName}
 	cRef := strings.Join(s, "-")
 
-	dpdkconfBytes, err := consumeScratchNetConf(cRef, dataDir)
+	confBytes, err := consumeScratchNetConf(cRef, dataDir)
 	if err != nil {
 		return err
 	}
 
-	if err = json.Unmarshal(dpdkconfBytes, dc); err != nil {
+	if err = json.Unmarshal(confBytes, nc); err != nil {
 		return fmt.Errorf("failed to parse netconf: %v", err)
 	}
 
 	return nil
+}
+
+func getOrderedPF(n *NetConf) ([]string, error) {
+	//check pf devices
+	var pfs pfStats
+	for _, pfName := range(n.PfNetdevices){
+		vfDir := fmt.Sprintf("/sys/class/net/%s/device/virtfn*/net/*", pfName)
+		vfs, err := filepath.Glob(vfDir)
+		if err != nil{
+			return nil, err
+		}
+		pfs = append(pfs, &pfStat{pfName, len(vfs)})
+	}
+
+	sort.Sort(pfs)
+
+	var result []string
+	for _, pf := range(pfs){
+		result = append(result, pf.PFName)
+	}
+	return result, nil
 }
 
 func enabledpdkmode(conf *dpdkConf, ifname string, dpdkmode bool) error {
@@ -406,12 +437,11 @@ func setupVF(conf *NetConf, ifName string, podifName string, cid string, netns n
 			}
 		}
 	}
-
+	conf.DPDKConf.PCIaddr = pciAddr
+	conf.DPDKConf.Ifname = podifName
+	conf.DPDKConf.VFID = vfIdx
 	if conf.DPDKMode != false {
-		conf.DPDKConf.PCIaddr = pciAddr
-		conf.DPDKConf.Ifname = podifName
-		conf.DPDKConf.VFID = vfIdx
-		if err = savedpdkConf(cid, conf.CNIDir, conf); err != nil {
+		if err = saveNetConf(cid, conf.CNIDir, conf); err != nil {
 			return err
 		}
 		return enabledpdkmode(&conf.DPDKConf, infos[0].Name(), true)
@@ -468,22 +498,57 @@ func setupVF(conf *NetConf, ifName string, podifName string, cid string, netns n
 				}
 			}
 		}
+		if err = saveNetConf(cid, conf.CNIDir, conf); err != nil {
+			return fmt.Errorf("failed to save pod interface name %q: %v", ifName, err)
+		}
 		return nil
 	})
 }
 
-func releaseVF(conf *NetConf, podifName string, cid string, netns ns.NetNS) error {
-	// check for the DPDK mode and release the allocated DPDK resources
-	if conf.DPDKMode != false {
-		df := &dpdkConf{}
-		// get the DPDK net conf in cniDir
-		if err := df.getdpdkConf(cid, podifName, conf.CNIDir, conf); err != nil {
+func setupVFHelper(conf *NetConf, ifName string, podifName string, cid string, netns ns.NetNS) error {
+	numOfDevices := len(conf.PfNetdevices)
+	if numOfDevices > 0 {
+		orderedPF, err := getOrderedPF(conf)
+		if err != nil {
 			return err
 		}
+		for _, pf := range(orderedPF){
+			conf.IF0 = pf
+			err = setupVF(conf, conf.IF0, ifName, cid, netns)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("failed to set up pod interface %q from the device %v: %v", ifName, conf.PfNetdevices, err)
+		}
+	} else {
+		if err := setupVF(conf, conf.IF0, ifName, cid, netns); err != nil {
+			return fmt.Errorf("failed to set up pod interface %q from the device %q: %v", ifName, conf.IF0, err)
+		}
+	}
+	return nil
+}
 
+func releaseVF(conf *NetConf, podifName string, cid string, netns ns.NetNS) error {
+
+	nf := &NetConf{}
+	// get the net conf in cniDir
+	if err := nf.getNetConf(cid, podifName, conf.CNIDir, conf); err != nil {
+		return err
+	}
+
+	//if conf.IF0 == "" {
+	//	conf.IF0 = nf.IF0
+	//} else if strings.Compare(conf.IF0, nf.IF0) != 0 {
+	//	return fmt.Errorf("master device %s not equal to %s, which config saved into files", conf.IF0, nf.IF0)
+	//}
+
+	// check for the DPDK mode and release the allocated DPDK resources
+	if nf.DPDKMode != false {
 		// bind the sriov vf to the kernel driver
-		if err := enabledpdkmode(df, df.Ifname, false); err != nil {
-			return fmt.Errorf("DPDK: failed to bind %s to kernel space: %s", df.Ifname, err)
+		if err := enabledpdkmode(&nf.DPDKConf, nf.DPDKConf.Ifname, false); err != nil {
+			return fmt.Errorf("DPDK: failed to bind %s to kernel space: %s", nf.DPDKConf.Ifname, err)
 		}
 
 		// reset vlan for DPDK code here
@@ -492,8 +557,8 @@ func releaseVF(conf *NetConf, podifName string, cid string, netns ns.NetNS) erro
 			return fmt.Errorf("DPDK: master device %s not found: %v", conf.IF0, err)
 		}
 
-		if err = netlink.LinkSetVfVlan(pfLink, df.VFID, 0); err != nil {
-			return fmt.Errorf("DPDK: failed to reset vlan tag for vf %d: %v", df.VFID, err)
+		if err = netlink.LinkSetVfVlan(pfLink, nf.DPDKConf.VFID, 0); err != nil {
+			return fmt.Errorf("DPDK: failed to reset vlan tag for vf %d: %v", nf.DPDKConf.VFID, err)
 		}
 
 		return nil
@@ -524,10 +589,10 @@ func releaseVF(conf *NetConf, podifName string, cid string, netns ns.NetNS) erro
 
 	for i := 1; i <= maxSharedVf; i++ {
 		ifName := podifName
-		pfName := conf.IF0
+		pfName := nf.IF0
 		if i == maxSharedVf {
 			ifName = podifName + fmt.Sprintf("d%d", i-1)
-			pfName, err = getSharedPF(conf.IF0)
+			pfName, err = getSharedPF(nf.IF0)
 			if err != nil {
 				return fmt.Errorf("Failed to look up shared PF device: %v:", err)
 			}
@@ -635,7 +700,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		os.Setenv("CNI_IFNAME", args.IfName)
 	}
 
-	err = setupVF(n, n.IF0, args.IfName, args.ContainerID, netns)
+	err = setupVFHelper(n, n.IF0, args.IfName, args.ContainerID, netns)
 	defer func() {
 		if err != nil {
 			err = netns.Do(func(_ ns.NetNS) error {
@@ -647,6 +712,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 			}
 		}
 	}()
+	if err != nil {
+		return err
+	}
+
 	// skip the IPAM allocation for the DPDK and L2 mode
 	var result *types.Result
 	if n.DPDKMode != false || n.L2Mode != false {


### PR DESCRIPTION
On our server, we have 2 ConnectX-5 EN Ethernet Cards, and each of them have 2 ports. So one server we have 4 port, but only one of them can be used by the original SRIOV-cni. To use all of them together, we  add pfNetdevices parameter, partly inspired by [Mellanox/k8s-rdma-sriov-dev-plugin](https://github.com/Mellanox/k8s-rdma-sriov-dev-plugin).

When the `setupVF` is called, it will do these things
1. check the pf devices configured by `pfNetdevices` first, to find out which pf device can be used.   
2. Then create the vf as usual
3. Save the whole `NetConf` not only `DPDKConf`, so that we can find which `pf` is used by `vf`
4. Save which `pf` should be use next time. (inspired by [ipam/host-local](https://github.com/containernetworking/plugins/tree/master/plugins/ipam/host-local))